### PR TITLE
Only run brew test-bot on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
 name: brew test-bot
-on:
-  push:
-    branches: master
-  pull_request: []
+
+on: pull_request
+
 jobs:
   test-bot:
     runs-on: macos-latest


### PR DESCRIPTION
The repo is configured to require the status check to pass and the branch to be up-to-date, so it's redundant to run again on master after a PR is merged.